### PR TITLE
Add more tweaks to CQ customizer

### DIFF
--- a/app/api/src/docker/cadquery/Dockerfile
+++ b/app/api/src/docker/cadquery/Dockerfile
@@ -42,7 +42,7 @@ RUN npm install aws-lambda-ric@1.0.0
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh 
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
 RUN conda --version
 
 # Install CadQuery

--- a/app/api/src/docker/cadquery/runCQ.ts
+++ b/app/api/src/docker/cadquery/runCQ.ts
@@ -12,7 +12,7 @@ export const runCQ = async ({
       {
         file: JSON.stringify(parameters),
         fileName: 'params.json',
-      }
+      },
     ],
     'a' + nanoid() // 'a' ensure nothing funny happens if it start with a bad character like "-", maybe I should pick a safer id generator :shrug:
   )
@@ -36,12 +36,12 @@ export const runCQ = async ({
   console.log('command', mainCommand)
   let consoleMessage = ''
   try {
-    ;([consoleMessage] = await Promise.all([
+    ;[consoleMessage] = await Promise.all([
       runCommand(mainCommand, 30000),
-      runCommand(customizerCommand, 30000)
-    ]))
+      runCommand(customizerCommand, 30000),
+    ])
     const params = JSON.parse(
-      await readFile(customizerPath, { encoding: 'ascii'})
+      await readFile(customizerPath, { encoding: 'ascii' })
     )
     await writeFiles(
       [
@@ -63,6 +63,6 @@ export const runCQ = async ({
     )
     return { consoleMessage, fullPath }
   } catch (error) {
-    return { error: consoleMessage, fullPath }
+    return { error: consoleMessage || error, fullPath }
   }
 }

--- a/app/web/src/helpers/cadPackages/cadQuery/cadQueryController.ts
+++ b/app/web/src/helpers/cadPackages/cadQuery/cadQueryController.ts
@@ -51,7 +51,7 @@ export const render: DefaultKernelExport['render'] = async ({
       data: await stlToGeometry(window.URL.createObjectURL(blob)),
       consoleMessage,
       date: new Date(),
-      customizerParams: CadQueryToCadhubParams([customizerParams]), // TODO, should already be an array and not need to be wrapped in one.
+      customizerParams: CadQueryToCadhubParams(customizerParams),
     })
   } catch (e) {
     return createUnhealthyResponse(new Date())

--- a/app/web/src/helpers/cadPackages/cadQuery/cadQueryParams.ts
+++ b/app/web/src/helpers/cadPackages/cadQuery/cadQueryParams.ts
@@ -2,8 +2,8 @@ import { CadhubParams } from 'src/components/Customizer/customizerConverter'
 
 interface CadQueryParamsBase {
   name: string
-  initial: number | string
-  type?: 'number'
+  initial: number | string | boolean
+  type?: 'number' | 'string' | 'boolean'
 }
 
 interface CadQueryNumberParam extends CadQueryParamsBase {
@@ -12,13 +12,19 @@ interface CadQueryNumberParam extends CadQueryParamsBase {
 }
 
 interface CadQueryStringParam extends CadQueryParamsBase {
+  type: 'string'
   initial: string
+}
+
+interface CadQueryBooleanParam extends CadQueryParamsBase {
+  type: 'boolean'
+  initial: boolean
 }
 
 export type CadQueryStringParams =
   | CadQueryNumberParam
   | CadQueryStringParam
-
+  | CadQueryBooleanParam
 
 export function CadQueryToCadhubParams(
   input: CadQueryStringParams[]
@@ -29,21 +35,29 @@ export function CadQueryToCadhubParams(
         caption: '',
         name: param.name,
       }
-      if(param.type === 'number') {
-        return {
-          type: 'number',
-          input: 'default-number',
-          ...common,
-          initial: Number(param.initial),
-        }
-      }
-      return {
-        type: 'string',
-        input: 'default-string',
-        ...common,
-        initial: String(param.initial),
+      switch (param.type) {
+        case 'number':
+          return {
+            type: 'number',
+            input: 'default-number',
+            ...common,
+            initial: param.initial,
+          }
+        case 'string':
+          return {
+            type: 'string',
+            input: 'default-string',
+            ...common,
+            initial: param.initial,
+          }
+        case 'boolean':
+          return {
+            type: 'boolean',
+            input: 'default-boolean',
+            ...common,
+            initial: param.initial,
+          }
       }
     })
     .filter((a) => a)
 }
-


### PR DESCRIPTION
Main tweaks here are how the incoming params are pressed in the browser, and that all seems to be working

![image](https://user-images.githubusercontent.com/29681384/136683251-cc88f51c-4440-4873-8765-f2b27ffead93.png)

Though I seeming the have trouble with the variables themselves, as in no matter how I change the variable values, either in the script or the customizer the model doesn't change

I also noticed that if I specify a parameter that doesn't exist in the script than it throws with `cadquery.cqgi.InvalidParameterError: Cannot set value 'aString': not a parameter of the model.` this seems like a problem to me as this will happen when ever the user comments out a variable as the customizer UI wont update to remove that variable until after the next render. I think it would be better if extra params are just ignored, that's how they're handled in JSCAD and OpenSCAD.